### PR TITLE
Feature/typography structure

### DIFF
--- a/css/README.md
+++ b/css/README.md
@@ -59,12 +59,11 @@ simple-selector > simple-selector {
 5. **vendor-overrides** (to re-declare some vendor CSS with help of settings and utilities, if needed)
 6. **reset** (e.g. [Reset CSS](http://meyerweb.com/eric/tools/css/reset/) or [normalize.css](http://necolas.github.io/normalize.css/), and [box-sizing](http://www.paulirish.com/2012/box-sizing-border-box-ftw/))
 7. **layout** (immutable objects, e.g. grid, body with a sticky footer, views)
-8. **typography** (e.g. headings, text, code, lists, quotes)
-9. **controls** (e.g. buttons, segmented-control, drop-down-menu, pop-up-menu, text-inputs)
-10. **components** (designed interface blocks: bars, dialogs, indicators)
-11. **pages** (page specific styles. Before you add page specific styles, consider modified components. Also note that components that can only be found on one page but still could be used on other pages should be placed in 'components')
-12. **themes** (for many projects non-existent)
-13. **overrides** (hacks and things you are not proud of)
+8. **controls** (e.g. buttons, segmented-control, drop-down-menu, pop-up-menu, text-inputs)
+9. **components** (designed interface blocks: bars, dialogs, indicators, content)
+10. **pages** (page specific styles. Before you add page specific styles, consider modified components. Also note that components that can only be found on one page but still could be used on other pages should be placed in 'components')
+11. **themes** (for many projects non-existent)
+12. **overrides** (hacks and things you are not proud of)
 
 See [The Specificity Graph](http://csswizardry.com/2014/10/the-specificity-graph/) and [CSS Specificity Graph Generator](http://jonassebastianohlsson.com/specificity-graph/) for more information about CSS specificity.
 
@@ -77,12 +76,11 @@ See [The Specificity Graph](http://csswizardry.com/2014/10/the-specificity-graph
 5. **vendor-overrides**: same as vendor's directories or file names.
 6. **reset**: original file name or function name.
 7. **layout**: name of container or function.
-8. **typography**: name of typographical group.
-9. **controls**: name of control.
-10. **components**: name of block.
-11. **pages**: name of page or template.
-12. **themes**: name of theme.
-13. **overrides**: depends on type.
+8. **controls**: name of control.
+9. **components**: name of block.
+10. **pages**: name of page or template.
+11. **themes**: name of theme.
+12. **overrides**: depends on type.
 
 ### Do not use @import for CSS files
 
@@ -381,7 +379,7 @@ See [BEM](https://bem.info), [CSS Wizardry](http://csswizardry.com/2013/01/mindb
 
 ### Never style HTML elements directly, always use class names.
 
-- Also applies to typographic elements such as 'h1' and 'p'. For user content or other content containing only HTML elements without class names, use the class '.content' as a container.
+- Also applies to typographic elements such as 'h1' and 'p'. For user content or other content containing only HTML elements without class names, use the class '.content' as a container. The 'content block' should be placed in the components folder.
 - Exception applies to rules in reset folder.
 
 **Right:**


### PR DESCRIPTION
Removed typography folder and makes clear the content block should be placed in 'components'.