### PR TITLE
Write durations in CSS/SCSS in milliseconds

### DIFF
--- a/css/README.md
+++ b/css/README.md
@@ -534,7 +534,7 @@ $color-primary-200: darken($color-primary-100, 10%)
 
 **Wrong:**
 ```SCSS
-$color-primary: #323232);
+$color-primary: #323232;
 ```
 
 See ['Name that Color'](http://chir.ag/projects/name-that-color/) for example for finding descriptive names.
@@ -955,7 +955,7 @@ simple-selector-1 {
 }
 ```
 
-### Color units should be written in 'HEX'
+### Color units should be written in 'HEX', RGBA can be used for transparency
 
 - It's easier to transfer HEX colors to a project as digital design applications often use HEX colors
 - Do not abbreviate HEX colors as it decreases readability
@@ -963,6 +963,7 @@ simple-selector-1 {
 **Right:**
 ```SCSS
 #ffffff;
+rgba(50, 50, 50, 0.5);
 ```
 
 **Wrong:**
@@ -971,7 +972,6 @@ hsl(120, 100%, 50%);
 hsla(120, 100%, 50%, 0.5);
 white;
 rgb(50, 50, 50);
-rgba(50, 50, 50, 0.5);
 #fff;
 ```
 

--- a/css/README.md
+++ b/css/README.md
@@ -522,7 +522,7 @@ $blue-color: ;
 ```SCSS
 // Descriptive colors
 
-$color-silver: rgb(50, 50, 50);
+$color-silver: #323232;
 
 // Functional colors
 
@@ -534,7 +534,7 @@ $color-primary-200: darken($color-primary-100, 10%)
 
 **Wrong:**
 ```SCSS
-$color-primary: rgb(50, 50, 50);
+$color-primary: #323232);
 ```
 
 See ['Name that Color'](http://chir.ag/projects/name-that-color/) for example for finding descriptive names.
@@ -955,24 +955,24 @@ simple-selector-1 {
 }
 ```
 
-### Color units should be written in 'HSL' or 'HSLa'
+### Color units should be written in 'HEX'
 
-- HSL or HSLa makes changing color values much easier.
-- Less or SCSS should convert HSL to hex color codes to reduce file size.
+- It's easier to transfer HEX colors to a project as digital design applications often use HEX colors
+- Do not abbreviate HEX colors as it decreases readability
 
 **Right:**
 ```SCSS
-hsl(120, 100%, 50%);
-hsla(120, 100%, 50%, 0.5);
+#ffffff;
 ```
 
 **Wrong:**
 ```SCSS
-#fff;
-#ffffff;
+hsl(120, 100%, 50%);
+hsla(120, 100%, 50%, 0.5);
 white;
 rgb(50, 50, 50);
 rgba(50, 50, 50, 0.5);
+#fff;
 ```
 
 ### Absolute sizes should be written in pixels instead of ems or rems
@@ -1086,14 +1086,14 @@ selector {
 ```SCSS
 // # Colors
 
-$color-blue: rgb(0, 0, 255); // #0000ff
+$color-blue: #0000ff; // rgb(0, 0, 255)
 ```
 
 **Wrong:**
 ```SCSS
 /* -- colors -- */
 
-$color-blue: rgb(0, 0, 255); /* #0000ff */
+$color-blue: #0000ff; /* rgb(0, 0, 255) */
 ```
 
 ### Use CSS commenting style '/* */' for comments useful for debugging

--- a/css/README.md
+++ b/css/README.md
@@ -48,6 +48,7 @@ simple-selector > simple-selector {
 - With Less or SCSS, never divide a rule group (e.g. BEM block) across different files.
 - With Less or SCSS, never combine different rule groups (e.g. BEM blocks) in one file.
 - Never use sub-folders to group files.
+- With Less or SCSS, each group should have an index file (e.g. '\_index.scss') which includes all the files from that directory. Only the indexes should be included in the main SCSS or Less file.
 - Rules within vendors, utilities, or layout are [immutable](http://csswizardry.com/2015/03/immutable-css/).
 
 **Order should be:**

--- a/css/README.md
+++ b/css/README.md
@@ -59,12 +59,11 @@ simple-selector > simple-selector {
 5. **vendor-overrides** (to re-declare some vendor CSS with help of settings and utilities, if needed)
 6. **reset** (e.g. [Reset CSS](http://meyerweb.com/eric/tools/css/reset/) or [normalize.css](http://necolas.github.io/normalize.css/), and [box-sizing](http://www.paulirish.com/2012/box-sizing-border-box-ftw/))
 7. **layout** (immutable objects, e.g. grid, body with a sticky footer, views)
-8. **typography** (e.g. headings, text, code, lists, quotes)
-9. **controls** (e.g. buttons, segmented-control, drop-down-menu, pop-up-menu, text-inputs)
-10. **components** (designed interface blocks: bars, dialogs, indicators)
-11. **pages** (page specific styles. Before you add page specific styles, consider modified components. Also note that components that can only be found on one page but still could be used on other pages should be placed in 'components')
-12. **themes** (for many projects non-existent)
-13. **overrides** (hacks and things you are not proud of)
+8. **controls** (e.g. buttons, segmented-control, drop-down-menu, pop-up-menu, text-inputs)
+9. **components** (designed interface blocks: bars, dialogs, indicators, content)
+10. **pages** (page specific styles. Before you add page specific styles, consider modified components. Also note that components that can only be found on one page but still could be used on other pages should be placed in 'components')
+11. **themes** (for many projects non-existent)
+12. **overrides** (hacks and things you are not proud of)
 
 See [The Specificity Graph](http://csswizardry.com/2014/10/the-specificity-graph/) and [CSS Specificity Graph Generator](http://jonassebastianohlsson.com/specificity-graph/) for more information about CSS specificity.
 
@@ -77,12 +76,11 @@ See [The Specificity Graph](http://csswizardry.com/2014/10/the-specificity-graph
 5. **vendor-overrides**: same as vendor's directories or file names.
 6. **reset**: original file name or function name.
 7. **layout**: name of container or function.
-8. **typography**: name of typographical group.
-9. **controls**: name of control.
-10. **components**: name of block.
-11. **pages**: name of page or template.
-12. **themes**: name of theme.
-13. **overrides**: depends on type.
+8. **controls**: name of control.
+9. **components**: name of block.
+10. **pages**: name of page or template.
+11. **themes**: name of theme.
+12. **overrides**: depends on type.
 
 ### Do not use @import for CSS files
 
@@ -381,7 +379,7 @@ See [BEM](https://bem.info), [CSS Wizardry](http://csswizardry.com/2013/01/mindb
 
 ### Never style HTML elements directly, always use class names.
 
-- Also applies to typographic elements such as 'h1' and 'p'. For user content or other content containing only HTML elements without class names, use the class '.content' as a container.
+- Also applies to typographic elements such as 'h1' and 'p'. For user content or other content containing only HTML elements without class names, use the class '.content' as a container. The 'content block' should be placed in the components folder.
 - Exception applies to rules in reset folder.
 
 **Right:**

--- a/javascript/typescript.md
+++ b/javascript/typescript.md
@@ -97,6 +97,12 @@ Define types in the comments
 - Private class variables are declared before public class variables
 - Private and public class methods can be defined in order of usage (for example, a private method can be placed in between 2 public methods if it is only used by the above public method)
 
+## Naming
+- Just like in [javascript](README.md#write-variables-in-camelcase), variables of any type are written in lower camelCase.
+- Classes, Interfaces and Enums are written in upper CamelCase (e.g. 'ProductInterface').
+- Classes get a suffix for what type of class it is (e.g. 'AppModule', 'AccountService' or 'CartComponent').
+- Interfaces get a 'Interface' suffix (e.g. 'ProductInterface')
+
 ## Example code
 ```typescript
 export class SomeClass {

--- a/naming/labels/README.md
+++ b/naming/labels/README.md
@@ -15,12 +15,12 @@ Examples:
 - notifications.idle-message-text -> Your session has expired because you were longer than %time% inactive. Please renew your selection.
 - login.password-label -> Your password
 
-## Categorize labels used in different components in ‘general’
+## Categorize labels used in different components in ‘global’
 
 Examples:
 
-- general.edit-action -> Edit
-- general.optional-lowercase -> optional
+- global.edit-action -> Edit
+- global.optional-lowercase -> optional
 
 ## Labels containing ‘exact translations’ should contain only the exact words and end with the type of capitalization
 
@@ -28,9 +28,9 @@ The descriptions for capitalization is borrowed from CSS’s text-transform. Alt
 
 Examples:
 
-- general.monday-capitalize -> Monday
-- general.monday-lowercase -> monday
-- general.monday-uppercase -> MONDAY
+- global.monday-capitalize -> Monday
+- global.monday-lowercase -> monday
+- global.monday-uppercase -> MONDAY
 
 ## Labels which are a abbreviations end with ‘short’
 
@@ -38,7 +38,7 @@ Capitalization type is added after the term ‘short’.
 
 Examples:
 
-- general.friday-short-capitalize -> Fr.
+- global.friday-short-capitalize -> Fr.
 
 ## Labels for a title end with ‘title’
 
@@ -93,7 +93,7 @@ File names should not include the format of the document. This should be added b
 
 Examples:
 
-- general.general-conditions-file-name -> general-conditions
+- global.general-conditions-file-name -> general-conditions
 
 ## Labels for buttons, links or actions end with action
 
@@ -101,4 +101,4 @@ The labels for buttons often differ in style per language, for example Dutch lab
 
 Examples:
 
-- general.close-action -> Close
+- global.close-action -> Close


### PR DESCRIPTION
Writing durations in functions in milliseconds in CSS/SCSS so durations in javascript and CSS/SCSS are the same, since javascript internally uses milliseconds. 

## Example (SCSS)
### Right: 
```scss
.selector {
    opacity: 0;
    transition: opacity 300ms linear;

    &:hover {
         opacity: 1;
    }
}
```
### Wrong:
```scss
.selector {
    opacity: 0;
    transition: opacity 0.3s linear;

    &:hover {
         opacity: 1;
    }
}
```
