### PR TITLE
Fix invalid JavaScript attribute conventions

### DIFF
--- a/html/README.md
+++ b/html/README.md
@@ -143,16 +143,16 @@ Always add a type to a button to prevent accidentally submitting forms
 ```
 
 ## Prefix JavaScript attributes
-When you want to target HTML in JavaScript use attributes prefixed with js-, don't use data-.
+When you want to target HTML in JavaScript use attributes prefixed with data-.
 
 **Right:**
 ```html
-<h1 js-component-title>Title</h1>
+<h1 data-component-title>Title</h1>
 ```
 
 **Wrong:**
 ```html
-<h1 data-component-title>Title</h1>
+<h1 js-component-title>Title</h1>
 <h1 component-title>Title</h1>
 ```
 

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -35,18 +35,18 @@ if (0 === '') // false
 if (0 == '') // true
 ```
 
-## Target dom elements with a js- prefixed attribute
+## Target dom elements with a data- prefixed attribute
 
 **Right:**
 ```javascript
-document.querySelectorAll('[js-component]');
+document.querySelectorAll('[data-component]');
 ```
 
 **Wrong:**
 ```javascript
 document.querySelectorAll('.component');
 
-document.querySelectorAll('[data-component]');
+document.querySelectorAll('[js-component]');
 
 document.querySelectorAll('[component]');
 ```


### PR DESCRIPTION
Since valid custom HTML attributes start with `data-` (https://www.w3.org/TR/2011/WD-html5-20110525/elements.html#embedding-custom-non-visible-data-with-the-data-attributes) I like to update the attribute conventions.